### PR TITLE
Remove RM head condition in enableExtensionSupport

### DIFF
--- a/cypress/e2e/unit-tests.spec.ts
+++ b/cypress/e2e/unit-tests.spec.ts
@@ -99,6 +99,6 @@ describe('Cypress Library e2e tests', () => {
   it('Check enableExtensionSupport function without rancher repo activated', () => {
     cy.login();
     cypressLib.burgerMenuToggle();
-    cypressLib.enableExtensionSupport(false, true);
+    cypressLib.enableExtensionSupport(false);
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -175,9 +175,8 @@ export function deleteUser(username) {
  * Enable the extension support
  * @remarks : Disable the Rancher Repo if you provide your own repo
  * @param withRancherRepo : Add the Rancher Extension Repository - boolean
- * @param isRancherHead : Tell if the test run on rancher head - boolean
  */
-export function enableExtensionSupport(withRancherRepo, isRancherHead) {
+export function enableExtensionSupport(withRancherRepo) {
   cy.contains('Extensions')
     .click();
   // Make sure we are on the Extensions page
@@ -185,19 +184,14 @@ export function enableExtensionSupport(withRancherRepo, isRancherHead) {
   cy.clickButton('Enable');
   cy.contains('Enable Extension Support?')
   if (!withRancherRepo) {
-    if (isRancherHead) {
-      cy.contains('Add Official Rancher Extensions Repository')
-        .click();
-      cy.contains('Add Partners Extensions Repository')
-        .click();
-    } else {
-      cy.contains('Add the Rancher Extension Repository')
-        .click();
-    }
+    cy.contains('Add Official Rancher Extensions Repository')
+      .click();
+    cy.contains('Add Partners Extensions Repository')
+      .click();
   }
-cy.clickButton('OK');
-cy.get('.tabs', {timeout: 40000})
-  .contains('Installed Available Updates All');
+  cy.clickButton('OK');
+  cy.get('.tabs', {timeout: 40000})
+    .contains('Installed Available Updates All');
 };
 
 /**


### PR DESCRIPTION
There is no text difference between latest rancher stable and head anymore so we can remove the condition inside the `enableExtensionSupport` function.

Tested locally with `rancher 2.7.9`
![image](https://github.com/rancher-sandbox/rancher-ecp-qa/assets/6025636/51527867-900e-4ba3-a92b-443f3574d0ab)
