### PR TITLE
Adding check to ensure "Loading..." overlay screen is not present.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -40,6 +40,8 @@ export function addRepository(repositoryName, repositoryURL, repositoryType, rep
     cy.clickNavMenu(['Apps', 'Repositories'])
   // Make sure we are in the 'Repositories' screen (test failed here before)
   // Test fails sporadically here, screen stays in pending state forever
+  // Ensuring "Loading..." overlay screen is not present.
+  cy.contains('Loading...', {timeout: 35000}).should('not.exist');
   cy.contains('header', 'Repositories')
     .should('be.visible');
   cy.contains('Create')


### PR DESCRIPTION
## Issue:

Sometimes in Rancher there is an overlay with `Loading...` while transitioning to pages. At times, if the overlay stays too long and the next command in the test is executed it may fail. This pr adds a check for this element not to exist in a particular moment after clicking in repositories. 

- Before addition:

![error_without_wait_for_loading_to_dissappear](https://github.com/rancher-sandbox/rancher-ecp-qa/assets/37271841/51a67594-4aaa-46a9-88d0-639456576855)



- After addition:

![ok_after](https://github.com/rancher-sandbox/rancher-ecp-qa/assets/37271841/b4dc99f0-b491-42a7-bec1-62e25da3433d)


