### PR TITLE
Tweak extension code when it is rancher head

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -177,8 +177,9 @@ export function deleteUser(username) {
  * Enable the extension support
  * @remarks : Disable the Rancher Repo if you provide your own repo
  * @param withRancherRepo : Add the Rancher Extension Repository - boolean
+ * @param isRancherHead : Tell if the test run on rancher head - boolean
  */
-export function enableExtensionSupport(withRancherRepo) {
+export function enableExtensionSupport(withRancherRepo, isRancherHead) {
   cy.contains('Extensions')
     .click();
   // Make sure we are on the Extensions page
@@ -186,10 +187,15 @@ export function enableExtensionSupport(withRancherRepo) {
   cy.clickButton('Enable');
   cy.contains('Enable Extension Support?')
   if (!withRancherRepo) {
-    cy.contains('Add Official Rancher Extensions Repository')
-      .click();
-    cy.contains('Add Partners Extensions Repository')
-      .click();
+    if (isRancherHead) {
+      cy.contains('Add Partners Extensions Repository')
+        .click();
+    } else {
+      cy.contains('Add Official Rancher Extensions Repository')
+        .click();
+      cy.contains('Add Partners Extensions Repository')
+        .click();
+    }
   }
   cy.clickButton('OK');
   cy.get('.tabs', {timeout: 40000})


### PR DESCRIPTION
Elemental UI tests fail due to a change in the extension management:
With Rancher stable, the extension screen is:
![image](https://github.com/rancher-sandbox/rancher-ecp-qa/assets/6025636/ad1430d8-d08e-4b88-9dce-11edd534b88e)

With Rancher head, it is:
![image](https://github.com/rancher-sandbox/rancher-ecp-qa/assets/6025636/b22d562d-67e1-45b3-901a-8f2b66462f65)

