### PR TITLE
Enhancement proposal/user auth uncheck default stduser

### DIFF
--- a/cypress/e2e/unit-tests.spec.ts
+++ b/cypress/e2e/unit-tests.spec.ts
@@ -88,15 +88,17 @@ describe('Cypress Library e2e tests', () => {
     cy.login();
     cypressLib.burgerMenuToggle();
     cypressLib.createUser('mytestuserwithrole', 'mytestpassword', 'User-Base', true);
-    // Log out
-    cy.get('.user.user-menu').click()
-    cy.contains('Log Out').should('be.visible').click();
-    // Log in with new user
+    // Log out with admin role and login with "User-Base" role to check
+    // "User-base" does not have these options available
+    cypressLib.logout();
     cy.login('mytestuserwithrole', 'mytestpassword');
     cypressLib.burgerMenuToggle();
-    // Check "User-base" does not have these options available
     cy.contains('Continue Delivery').should('not.exist');
     cy.contains('Cluster Management').should('not.exist');
+    // Log out as user and login back as admin to delete created user
+    cypressLib.logout();
+    cy.login();
+    cypressLib.burgerMenuToggle();
     cypressLib.deleteUser('mytestuserwithrole');
   });
 

--- a/cypress/e2e/unit-tests.spec.ts
+++ b/cypress/e2e/unit-tests.spec.ts
@@ -102,6 +102,26 @@ describe('Cypress Library e2e tests', () => {
     cypressLib.deleteUser('mytestuserwithrole');
   });
 
+it('Check createUser/deleteUser function with "Standard User" role', () => {
+  cy.login();
+  cypressLib.burgerMenuToggle();
+  // Given that Standard User is checked by default, no need to add role
+  cy.createUser('mytestuserwithrole', 'mytestpassword');
+  // Log out with admin role and login with "Standard User" role to check
+  // "Standard User" does not have some options available and has some others
+  cy.logout();
+  cy.login('mytestuserwithrole', 'mytestpassword');
+  cypressLib.burgerMenuToggle();
+  cy.contains('Continue Delivery').should('not.exist');
+  cy.contains('Extensions').should('not.exist');
+  cy.contains('Cluster Management').should('exist');
+  // Log out as user and login back as admin to delete created user
+  cy.logout();
+  cy.login();
+  cypressLib.burgerMenuToggle();
+  cypressLib.deleteUser('mytestuserwithrole');
+});
+
   it('Check enableExtensionSupport function with rancher repo activated', () => {
     cy.login();
     cypressLib.burgerMenuToggle();

--- a/cypress/e2e/unit-tests.spec.ts
+++ b/cypress/e2e/unit-tests.spec.ts
@@ -84,6 +84,22 @@ describe('Cypress Library e2e tests', () => {
     cypressLib.deleteUser('mytestuserwithoutrole');
   });
 
+  it('Check createUser/deleteUser function with "User-Base" role and uncheck "Standard User"', () => {
+    cy.login();
+    cypressLib.burgerMenuToggle();
+    cypressLib.createUser('mytestuserwithrole', 'mytestpassword', 'User-Base', true);
+    // Log out
+    cy.get('.user.user-menu').click()
+    cy.contains('Log Out').should('be.visible').click();
+    // Log in with new user
+    cy.login('mytestuserwithrole', 'mytestpassword');
+    cypressLib.burgerMenuToggle();
+    // Check "User-base" does not have these options available
+    cy.contains('Continue Delivery').should('not.exist');
+    cy.contains('Cluster Management').should('not.exist');
+    cypressLib.deleteUser('mytestuserwithrole');
+  });
+
   it('Check enableExtensionSupport function with rancher repo activated', () => {
     cy.login();
     cypressLib.burgerMenuToggle();

--- a/cypress/e2e/unit-tests.spec.ts
+++ b/cypress/e2e/unit-tests.spec.ts
@@ -106,17 +106,17 @@ it('Check createUser/deleteUser function with "Standard User" role', () => {
   cy.login();
   cypressLib.burgerMenuToggle();
   // Given that Standard User is checked by default, no need to add role
-  cy.createUser('mytestuserwithrole', 'mytestpassword');
+  cypressLib.createUser('mytestuserwithrole', 'mytestpassword');
   // Log out with admin role and login with "Standard User" role to check
   // "Standard User" does not have some options available and has some others
-  cy.logout();
+  cypressLib.logout();
   cy.login('mytestuserwithrole', 'mytestpassword');
   cypressLib.burgerMenuToggle();
   cy.contains('Continue Delivery').should('not.exist');
   cy.contains('Extensions').should('not.exist');
   cy.contains('Cluster Management').should('exist');
   // Log out as user and login back as admin to delete created user
-  cy.logout();
+  cypressLib.logout();
   cy.login();
   cypressLib.burgerMenuToggle();
   cypressLib.deleteUser('mytestuserwithrole');

--- a/index.ts
+++ b/index.ts
@@ -132,9 +132,10 @@ export function confirmDelete() {
  * @param username : Name of the user
  * @param password : Password of the user
  * @param role : Role of the user
+ * @param uncheckStandardUser : Uncheck "Standard User" marked by default
  */
 // TODO: Add the possibility to add multiple roles
-export function createUser(username, password, role) {
+export function createUser(username, password, role, uncheckStandardUser=false) {
   cy.contains('Users & Authentication')
     .click();
   cy.contains('.title', 'Users')
@@ -144,10 +145,13 @@ export function createUser(username, password, role) {
   cy.typeValue('New Password', password);
   cy.typeValue('Confirm Password', password);
   if (role) {
-    // Uncheck "Standard User" marked by default first
-    cy.get('span[aria-label="Standard User"]').click();
     cy.contains(role)
-      .click();
+    .click();
+  } 
+  if (uncheckStandardUser === true) {
+  cy.get('span[aria-label="Standard User"]').scrollIntoView;
+  cy.contains('Standard User').should('be.visible');
+  cy.get('span[aria-label="Standard User"]').click();
   }
   cy.getBySel('form-save')
     .contains('Create')

--- a/index.ts
+++ b/index.ts
@@ -144,6 +144,8 @@ export function createUser(username, password, role) {
   cy.typeValue('New Password', password);
   cy.typeValue('Confirm Password', password);
   if (role) {
+    // Uncheck "Standard User" marked by default first
+    cy.get('span[aria-label="Standard User"]').click();
     cy.contains(role)
       .click();
   }

--- a/index.ts
+++ b/index.ts
@@ -184,9 +184,9 @@ export function deleteUser(username) {
  * @remarks : Useful when testing role changes
  */
 export function logout() {
-  cy.get('.user.user-menu').click()
-  cy.contains('Log Out').should('be.visible').click();
-  cy.contains('You have been logged out.').should('be.visible')
+  cy.get('.user.user-menu').click({ force: true });
+  cy.contains('Log Out').should('be.visible').click({ force: true });
+  cy.contains('You have been logged out.').should('be.visible');
 } 
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -180,6 +180,16 @@ export function deleteUser(username) {
 }
 
 /**
+ * Logout with the current user
+ * @remarks : Useful when testing role changes
+ */
+export function logout() {
+  cy.get('.user.user-menu').click()
+  cy.contains('Log Out').should('be.visible').click();
+  cy.contains('You have been logged out.').should('be.visible')
+} 
+
+/**
  * Enable the extension support
  * @remarks : Disable the Rancher Repo if you provide your own repo
  * @param withRancherRepo : Add the Rancher Extension Repository - boolean

--- a/index.ts
+++ b/index.ts
@@ -149,8 +149,8 @@ export function createUser(username, password, role, uncheckStandardUser=false) 
     .click();
   } 
   if (uncheckStandardUser === true) {
-  cy.get('span[aria-label="Standard User"]').scrollIntoView;
-  cy.contains('Standard User').should('be.visible');
+  cy.get('span[aria-label="Standard User"]').scrollIntoView();
+  cy.contains('Standard User').should('exist');
   cy.get('span[aria-label="Standard User"]').click();
   }
   cy.getBySel('form-save')


### PR DESCRIPTION
### Issue
---
When creating a user in `Users & Authentication`, the option `Standard User` is preselected, so if another option with lower permissions, like "User-Base" is marked without deselecting the `Standard User` one first, we will not be granted the desired restricted permissions, but more:
![image](https://github.com/rancher-sandbox/rancher-ecp-qa/assets/37271841/0910d87b-2348-40b9-8d93-43d7d5e8216f)


### Done
- Extend function `createUser` with a flag to deselect the pre-selected `Standard User` option.
- Add unit test to confirm deselection works and the `User-base` role has correct permissions.
- Add unit test to confirm deselection is disabled if not set to `true` and default creation of `Standard` role has correct permissions.

### Additional info 
I tried to confirm the selection/deselection of the check using locators, but I did not find a change on the UI on its state, so to check if the flag had been correctly removed, I added a logout and a new login with the specific user to later check if some restricted options like `Continuous Delivery` were accessible to the user.