### PR TITLE
Fix issue in checkClusterStatus with RM 2.10

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -99,13 +99,15 @@ export function burgerMenuToggle() {
  * @remarks : Checked in the Home page
  * @param clusterName : Name of the cluster
  * @param clusterStatus : Expected status of the cluster
+ * @param rancherVersion : Rancher version
  * @param timeout : Timeout for the check
  */
-export function checkClusterStatus(clusterName, clusterStatus, timeout) {
-    cy.contains('Home')
-      .click();
-    // The new cluster must be in active state
-    cy.contains(new RegExp(clusterStatus+'.*'+clusterName),  {timeout: timeout});
+export function checkClusterStatus(clusterName, clusterStatus, rancherVersion, timeout) {
+  cy.contains('Home')
+    .click();
+    (rancherVersion == '2.10') ?
+    cy.contains(clusterStatus+clusterName,  {timeout: timeout}) :
+    cy.contains(clusterStatus+' '+clusterName,  {timeout: timeout});
 };
 
 /**


### PR DESCRIPTION
Fix issue with Regex to check the cluster status
Failure [here](https://github.com/rancher/elemental/actions/runs/11849171146/job/33032369721)

Without the PR, this test continues even it the cluster is in the updating status:
![image](https://github.com/user-attachments/assets/5dc85810-1105-42f1-b094-0bcc1e077327)
