### PR TITLE
Update byLabel

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -289,7 +289,7 @@ Cypress.Commands.add("getBySel", (selector, ...args) => {
 
 Cypress.Commands.add('byLabel', (label) => {
   cy.get('.labeled-input')
-    .contains(label)
+    .contains(new RegExp(`^${label}`))
     .siblings('input');
 });
 


### PR DESCRIPTION
Updates byLabel command to match label text more strictly.
End text of label is not checked since some of them contain `*` (required) 