### PR TITLE
Bump Rancher for unit tests

### DIFF
--- a/cypress/e2e/unit-tests.spec.ts
+++ b/cypress/e2e/unit-tests.spec.ts
@@ -18,7 +18,7 @@ because there are called in the functions. No need to duplicate
 the tests.
 */
 
-import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+import * as cypressLib from '../../index';
 
 Cypress.config();
 describe('Cypress Library e2e tests', () => {
@@ -34,8 +34,8 @@ describe('Cypress Library e2e tests', () => {
       .contains('Cluster Management');
     // Close the menu
     cypressLib.burgerMenuToggle();
-    cy.getBySel('side-menu')
-      .should('not.be.visible');
+    cy.get('.menu-close')
+      .should('exist');
   });
 
   it('Check accessMenu function', () => {
@@ -46,6 +46,7 @@ describe('Cypress Library e2e tests', () => {
 
   it('Check addRepository function', () => {
     cy.login();
+    cypressLib.burgerMenuToggle();
     cypressLib.addRepository('elemental-ui', 'https://github.com/rancher/elemental-ui.git', 'git', 'gh-pages');
   });
 
@@ -63,6 +64,7 @@ describe('Cypress Library e2e tests', () => {
 
   it('Check confirmDelete function', () => {
     cy.login();
+    cy.viewport(1920, 1080);
     cypressLib.burgerMenuToggle();
     // confirmDelete function is called in deleteRepository function
     cypressLib.deleteRepository('elemental-ui');
@@ -102,41 +104,23 @@ describe('Cypress Library e2e tests', () => {
     cypressLib.deleteUser('mytestuserwithrole');
   });
 
-it('Check createUser/deleteUser function with "Standard User" role', () => {
-  cy.login();
-  cypressLib.burgerMenuToggle();
-  // Given that Standard User is checked by default, no need to add role
-  cypressLib.createUser('mytestuserwithrole', 'mytestpassword');
-  // Log out with admin role and login with "Standard User" role to check
-  // "Standard User" does not have some options available and has some others
-  cypressLib.logout();
-  cy.login('mytestuserwithrole', 'mytestpassword');
-  cypressLib.burgerMenuToggle();
-  cy.contains('Continue Delivery').should('not.exist');
-  cy.contains('Extensions').should('not.exist');
-  cy.contains('Cluster Management').should('exist');
-  // Log out as user and login back as admin to delete created user
-  cypressLib.logout();
-  cy.login();
-  cypressLib.burgerMenuToggle();
-  cypressLib.deleteUser('mytestuserwithrole');
-});
-
-  it('Check enableExtensionSupport function with rancher repo activated', () => {
+  it('Check createUser/deleteUser function with "Standard User" role', () => {
     cy.login();
     cypressLib.burgerMenuToggle();
-    cypressLib.enableExtensionSupport(true);
-  });
-
-  it('Check disableExtensionSupport function', () => {
+    // Given that Standard User is checked by default, no need to add role
+    cypressLib.createUser('mytestuserwithrole', 'mytestpassword');
+    // Log out with admin role and login with "Standard User" role to check
+    // "Standard User" does not have some options available and has some others
+    cypressLib.logout();
+    cy.login('mytestuserwithrole', 'mytestpassword');
+    cypressLib.burgerMenuToggle();
+    cy.contains('Continue Delivery').should('not.exist');
+    cy.contains('Extensions').should('not.exist');
+    cy.contains('Cluster Management').should('exist');
+    // Log out as user and login back as admin to delete created user
+    cypressLib.logout();
     cy.login();
     cypressLib.burgerMenuToggle();
-    cypressLib.disableExtensionSupport();
-  });
-
-  it('Check enableExtensionSupport function without rancher repo activated', () => {
-    cy.login();
-    cypressLib.burgerMenuToggle();
-    cypressLib.enableExtensionSupport(false);
+    cypressLib.deleteUser('mytestuserwithrole');
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,8 @@ export function accesMenu(menu) {
  * @param repositoryBranch : Branch of the repository
  */
 export function addRepository(repositoryName, repositoryURL, repositoryType, repositoryBranch) {
-  cy.contains('local')
+  cy.getBySel('side-menu')
+    .contains('local')
     .click();
     cy.clickNavMenu(['Apps', 'Repositories'])
   // Make sure we are in the 'Repositories' screen (test failed here before)
@@ -69,9 +70,10 @@ export function addRepository(repositoryName, repositoryURL, repositoryType, rep
  * @param repositoryName : Name of the repository to delete
  */
 export function deleteRepository(repositoryName) {
-  cy.contains('local')
+  cy.getBySel('side-menu')
+    .contains('local')
     .click();
-    cy.clickNavMenu(['Apps', 'Repositories'])
+  cy.clickNavMenu(['Apps', 'Repositories'])
   // Make sure we are in the 'Repositories' screen (test failed here before)
   cy.contains('header', 'Repositories')
     .should('be.visible');
@@ -105,7 +107,7 @@ export function burgerMenuToggle() {
 export function checkClusterStatus(clusterName, clusterStatus, rancherVersion, timeout) {
   cy.contains('Home')
     .click();
-    (rancherVersion == '2.10') ?
+    (rancherVersion != '2.9') ?
     cy.contains(clusterStatus+clusterName,  {timeout: timeout}) :
     cy.contains(clusterStatus+' '+clusterName,  {timeout: timeout});
 };
@@ -192,6 +194,8 @@ export function logout() {
 } 
 
 /**
+ * DEPRECATED ! not needed anymore since Rancher 2.9
+ * 
  * Enable the extension support
  * @remarks : Disable the Rancher Repo if you provide your own repo
  * @param withRancherRepo : Add the Rancher Extension Repository - boolean
@@ -214,6 +218,7 @@ export function enableExtensionSupport(withRancherRepo) {
 
 /**
  * Disable the extension support
+ * DEPRECATED ! not needed anymore since Rancher 2.9
  */
 export function disableExtensionSupport() {
   cy.contains('Extensions')

--- a/index.ts
+++ b/index.ts
@@ -104,7 +104,7 @@ export function burgerMenuToggle() {
  * @param rancherVersion : Rancher version
  * @param timeout : Timeout for the check
  */
-export function checkClusterStatus(clusterName, clusterStatus, rancherVersion, timeout) {
+export function checkClusterStatus(clusterName, clusterStatus, rancherVersion, timeout = 10000) {
   cy.contains('Home')
     .click();
     (rancherVersion != '2.9') ?

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/rancher-sandbox/rancher-ecp-qa#readme",
   "devDependencies": {
-    "cypress": "^10.0.0",
+    "cypress": "^13.9.0",
     "typescript": "^4.5.2",
     "@typescript-eslint/parser": "^6.2.0",
     "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/scripts/start-rancher
+++ b/scripts/start-rancher
@@ -6,7 +6,7 @@ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -e CATTLE_PASSWORD_MIN_LENGTH=3 \
   --name cypress \
   --privileged \
-  rancher/rancher:v2.10-head
+  rancher/rancher:head
 
 docker ps
 

--- a/scripts/start-rancher
+++ b/scripts/start-rancher
@@ -6,7 +6,7 @@ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -e CATTLE_PASSWORD_MIN_LENGTH=3 \
   --name cypress \
   --privileged \
-  rancher/rancher:v2.7-head
+  rancher/rancher:v2.10-head
 
 docker ps
 


### PR DESCRIPTION
- Bump Rancher from `2.7-head` to `head` (I will add a test matrix in a next PR)
- Fix the unit tests to work with new Rancher versions
- Bump Cypress from 10.0.0 to 13.9.0