### PR TITLE
loginPath api string patch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -108,7 +108,7 @@ export function checkClusterStatus(clusterName, clusterStatus, rancherVersion, t
   cy.contains('Home')
     .click();
     (rancherVersion != 'v2.9-head') ?
-    cy.contains(clusterStatus+clusterName,  {timeout: timeout}) :
+    cy.contains(new RegExp(clusterStatus+'.*'+clusterName), {timeout: timeout}) :
     cy.contains(clusterStatus+' '+clusterName,  {timeout: timeout});
 };
 
@@ -272,9 +272,9 @@ Cypress.Commands.add('login', (
   password = Cypress.env('password'),
   cacheSession = Cypress.env('cache_session')) => {
     const login = () => {
-      const loginPath ="/v3-public/localProviders/local*";
+      const loginPath = new RegExp('^\/v(1|3)-public\/.*login$')
       cy.intercept('POST', loginPath).as('loginReq');
-      
+
       cy.visit('/auth/login');
 
       cy.getBySel('local-login-username')

--- a/scripts/start-rancher
+++ b/scripts/start-rancher
@@ -18,7 +18,7 @@ echo "Waiting for dashboard UI to be reachable ..."
 
 okay=0
 
-while [ $okay -lt 20 ]; do
+while [ $okay -lt 30 ]; do
   STATUS=$(curl --silent --head -k https://127.0.0.1/dashboard/ | awk '/^HTTP/{print $2}')
 
   echo "Status: $STATUS (Try: $okay)"


### PR DESCRIPTION
- loginPath string patch to allow new api path from 2.14 onwards - `/v1-public/login`
- Fix `checkClusterStatus` function for failing unit tets