### PR TITLE
Bump and pin actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,10 +15,10 @@ jobs:
       NODE_VERSION: current
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         env:
           NODE_VERSION: current
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -45,7 +45,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: cypress-screenshots-${{ matrix.rancher_version }}
+          name: cypress-screenshots-${{ matrix.rancher_version }}-${{ github.run_number }}
           path: cypress/screenshots
           retention-days: 7
           if-no-files-found: ignore
@@ -55,6 +55,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: cypress-videos-${{ matrix.rancher_version }}
+          name: cypress-videos-${{ matrix.rancher_version }}-${{ github.run_number }}
           path: cypress/videos
           retention-days: 7

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,19 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         env:
           NODE_VERSION: current
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Deploy rancher 
+      - name: Deploy rancher
         run: npm run start-rancher
-        env: 
+        env:
           RANCHER_VERSION: ${{ matrix.rancher_version }}
 
       - name: Build package from the current branch
@@ -38,12 +38,12 @@ jobs:
 
       - name: Run e2e tests
         run: npm run start-unit-tests
-        env: 
+        env:
           RANCHER_VERSION: ${{ matrix.rancher_version }}
 
       - name: Upload Cypress screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cypress-screenshots-${{ matrix.rancher_version }}
           path: cypress/screenshots
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Cypress videos
         # Test run video is always captured, so this action uses "always()" condition
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cypress-videos-${{ matrix.rancher_version }}
           path: cypress/videos


### PR DESCRIPTION
This is attempt to bump and pin github actions by using their commit SHAs.

The actions were not updated for a while ~so there might be some compatibility issue~ - I had to expand name for upload-artifacts by `github.run_number` value.

Tested in my fork, see https://github.com/thehejik/rancher-ecp-qa/actions
* Lint and Unit-test workflows are ok
* Publish workflow not tested but it's using very same actions so it should be good