### PR TITLE
Updatecli and additional pinning of github actions

### DIFF
--- a/.github/updatecli/README.md
+++ b/.github/updatecli/README.md
@@ -1,0 +1,96 @@
+# Updatecli workflow
+
+This directory contains the [Updatecli](https://www.updatecli.io/) configuration used to keep this repository up to date automatically.
+
+## Purpose
+
+The Updatecli workflow is used to:
+
+- detect new versions of tracked dependencies or referenced components
+- update repository files when a newer version is available
+- open automated pull requests with the proposed changes
+
+## Location
+
+All Updatecli manifests and supporting files for this repository live under:
+
+```text
+.github/updatecli/
+```
+
+Github Actions workflows that run Updatecli are defined in:
+
+```text
+.github/workflows/updatecli.yaml
+```
+
+## How it works
+
+At a high level, the workflow follows this process:
+
+1. Read one or more Updatecli manifest files from this directory.
+2. Query defined sources for the latest available versions.
+3. Compare them with the versions currently referenced in the repository.
+4. Apply updates to the target files when changes are needed.
+5. Create or refresh a pull request containing the generated updates.
+
+Each manifest/pipeline will create a separate pull request if updates are detected. The PRs will be labeled and targeted to the branch defined in `values.yaml`.
+
+## Typical manifest structure
+
+An Updatecli manifest usually defines:
+
+- **sources**: where a version or value is discovered
+- **targets**: the files or values to update in this repository
+- **actions**: follow-up operations such as creating a pull request.
+
+The actions part is done by `_scm.github.yaml` template which is loaded automatically for all manifest. The template uses values from `values.yaml` file for PR labels and destination branch name.
+
+In general the `values.yaml` is used to inject values used by manifests.
+
+## Running locally
+
+If Updatecli is installed, manifests from this directory can be tested locally.
+
+Needed variables for a local run:
+
+```bash
+# gh auth status
+# gh auth refresh -s workflow
+export UPDATECLI_GITHUB_TOKEN=$(gh auth token)
+export UPDATECLI_ACTOR=<username>
+```
+
+Example:
+
+```bash
+# Dry run
+updatecli pipeline diff --config .github/updatecli/updatecli.d/ --values .github/updatecli/values.yaml
+
+# Update with creating PRs
+updatecli pipeline apply --config .github/updatecli/updatecli.d/ --values .github/updatecli/values.yaml
+```
+
+Use `diff` to preview changes before applying them.
+
+Render updatecli manifests for debugging purposes:
+
+```bash
+updatecli show --debug  --config .github/updatecli/updatecli.d/logging_stack.yaml --values .github/updatecli/values.yaml
+```
+
+## CI usage
+
+This directory is intended to be consumed by a GitHub Actions workflow or another automation job that runs Updatecli on a schedule or on demand.
+
+> [!IMPORTANT]
+> A GitHub personal access token (PAT) with `workflow` permission required.
+> The default `GITHUB_TOKEN` cannot modify files under `.github/workflows/`, which prevents workflows from self-modifying.
+> Use a classic PAT with the `workflow` scope, or an equivalent token with workflow write access.
+
+
+## Notes
+
+- Keep manifests focused and easy to review.
+- Prefer deterministic sources and explicit version selection ideally with `kind: githubrelease` source, to avoid unexpected updates.
+- Validate generated changes before merging automated pull requests.

--- a/.github/updatecli/updatecli.d/_scm.github.yaml
+++ b/.github/updatecli/updatecli.d/_scm.github.yaml
@@ -1,0 +1,54 @@
+# WARNING: This is slightly modified initial template for github scm.
+# Adding force push and and uses labels for PRs defined in values.yaml.
+
+# NOTE: Files prefixed with an underscore are partial Updatecli configuration
+# templates. They are intended to be included into other Updatecli manifests
+# and are not full standalone documents unless you explicitly make them so
+# (for example by adding a leading `---` and providing all required fields).
+
+# {{ if and .scm.enabled ( eq .scm.kind "github" ) }}
+# {{ $GitHubUser := env "UPDATECLI_ACTOR"}}
+# {{ $GitHubUsername := env "UPDATECLI_ACTOR"}}
+# {{ $GitHubPAT := env .scm.env_token }}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+actions:
+  default:
+    kind: "github/pullrequest"
+    spec:
+      #{{ if .automerge }}
+      automerge: {{.automerge }}
+      # {{ end }}
+      # {{ if .scm.labels }}
+      labels:
+        # {{ range .scm.labels }}
+        - '{{ . }}'
+        # {{ end }}
+      # {{ end }}
+      mergemethod: "squash"
+    scmid: "default"
+
+scms:
+  default:
+    kind: "github"
+    spec:
+      # {{ if .scm.user }}
+      user: '{{ default $GitHubUser .scm.user }}'
+      # {{ end }}
+      # {{ if .scm.email }}
+      email: '{{ .scm.email }}'
+      # {{ end }}
+      owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
+      repository: '{{ default $GitHubRepositoryList._1 .scm.repository }}'
+      token: '{{ default $GitHubPAT .scm.token }}'
+      username: '{{ default $GitHubUsername  .scm.username }}'
+      #{{ if .scm.branch }}
+      branch: '{{ .scm.branch }}'
+      #{{ end }}
+      # {{ if .scm.commitusingapi }}
+      commitusingapi: {{.scm.commitusingapi}}
+      # {{ end }}
+      # {{ if .scm.url }}
+      url: '{{ .scm.url }}'
+      # {{ end }}
+      force: true
+# {{ end }}

--- a/.github/updatecli/updatecli.d/github_runner.yaml
+++ b/.github/updatecli/updatecli.d/github_runner.yaml
@@ -1,0 +1,52 @@
+name: "[updatecli] Bump GitHub Runner"
+pipelineid: "github_runner_update"
+
+sources:
+  runnerVersion:
+    name: "Get latest GitHub Runner version"
+    kind: "githubrelease"
+    spec:
+      owner: "actions"
+      repository: "runner"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+    transformers:
+      - trimprefix: "v"
+
+  runnerSha:
+    name: "Get GitHub Runner SHA256"
+    kind: "shell"
+    spec:
+      # Read checksum from the release asset metadata (digest) in the GitHub Releases API
+      command: >
+        curl -fsSL https://api.github.com/repos/actions/runner/releases/tags/v{{ source "runnerVersion" }}
+        | jq -r '.assets[] | select(.name == "actions-runner-linux-x64-{{ source "runnerVersion" }}.tar.gz")
+        | .digest | sub("^sha256:"; "")'
+    dependson:
+      - runnerVersion
+
+targets:
+  runnerVersion:
+    name: "Update RUNNER_VERSION"
+    kind: "file"
+    sourceid: runnerVersion
+    # {{ if .scm.enabled }}
+    scmid: default
+    actionid: default
+    # {{ end }}
+    spec:
+      file: "scripts/gcp-template-tofu/configure-gh-runner.sh"
+      matchpattern: 'RUNNER_VERSION=".*"'
+      replacepattern: 'RUNNER_VERSION="{{ source "runnerVersion" }}"'
+
+  runnerSha:
+    name: "Update RUNNER_SHA256"
+    kind: "file"
+    sourceid: runnerSha
+    # {{ if .scm.enabled }}
+    scmid: default
+    actionid: default
+    # {{ end }}
+    spec:
+      file: "scripts/gcp-template-tofu/configure-gh-runner.sh"
+      matchpattern: 'RUNNER_SHA256=".*"'
+      replacepattern: 'RUNNER_SHA256="{{ source "runnerSha" }}"'

--- a/.github/updatecli/values.yaml
+++ b/.github/updatecli/values.yaml
@@ -1,0 +1,13 @@
+scm:
+  enabled: false
+  kind: github
+  env_token: UPDATECLI_GITHUB_TOKEN
+  owner: "rancher-sandbox"
+  repository: "rancher-ecp-qa"
+  #username: "updatecli[bot]"
+  #user: "updatecli[bot]"
+  #email: updatecli[bot]@users.noreply.github.com
+  branch: main
+  labels:
+    - "dependencies"
+    - "updatecli"

--- a/.github/updatecli/values.yaml
+++ b/.github/updatecli/values.yaml
@@ -1,5 +1,5 @@
 scm:
-  enabled: false
+  enabled: true
   kind: github
   env_token: UPDATECLI_GITHUB_TOKEN
   owner: "rancher-sandbox"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload Cypress screenshots
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cypress-screenshots-${{ matrix.rancher_version }}-${{ github.run_number }}
           path: cypress/screenshots
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Cypress videos
         # Test run video is always captured, so this action uses "always()" condition
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cypress-videos-${{ matrix.rancher_version }}-${{ github.run_number }}
           path: cypress/videos

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,26 @@
+name: "Updatecli"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@7aab164eed4ee3bb279611182ba1e62a3a867640 # v3.1.1
+
+      - name: Apply
+        run: "updatecli pipeline apply --config .github/updatecli/updatecli.d/ --values .github/updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.UPDATECLI_GITHUB_TOKEN }}"
+          UPDATECLI_ACTOR: "${{ github.actor }}"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: Apply
         run: "updatecli pipeline apply --config .github/updatecli/updatecli.d/ --values .github/updatecli/values.yaml"
         env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.UPDATECLI_GITHUB_TOKEN }}"
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           UPDATECLI_ACTOR: "${{ github.actor }}"

--- a/generate-tests-readme/workflow_template_update-tests-description.yaml
+++ b/generate-tests-readme/workflow_template_update-tests-description.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # A token is needed to be able to push on main, maybe this can be changed later
           # with another GHA or with some webhook?
@@ -32,7 +32,7 @@ jobs:
           if [[ "${NEW_CHK}" != "${OLD_CHK}" ]]; then
             echo "generate=needed" >> ${GITHUB_OUTPUT}
           fi
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         if: steps.readme_generator.outputs.generate == 'needed'
         with:
           default_author: github_actions

--- a/scripts/gcp-template-tofu/configure-gh-runner.sh
+++ b/scripts/gcp-template-tofu/configure-gh-runner.sh
@@ -6,10 +6,8 @@ GH_USER=gh-runner
 GCLOUD_BIN=gcloud
 RUNNER_HOME=/home/${GH_USER}
 RUNNER_DIR=${RUNNER_HOME}/actions-runner
-# renovate: datasource=github-releases depName=actions/runner
-RUNNER_VERSION=2.333.1
-# renovate: datasource=custom depName=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz.sha256
-RUNNER_SHA256=18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74
+RUNNER_VERSION="2.333.1"
+RUNNER_SHA256="18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74"
 RUNNER_PKG="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 RUNNER_TAR_FILE=runner.tar.gz
 


### PR DESCRIPTION
* use semver schema
* pinning in one additional workflow file
* new updatecli pipeline for bumping github runner version in configure-gh-runner.sh script