### PR TITLE
Sign commits by updatecli

### DIFF
--- a/.github/updatecli/updatecli.d/_scm.github.yaml
+++ b/.github/updatecli/updatecli.d/_scm.github.yaml
@@ -51,4 +51,8 @@ scms:
       url: '{{ .scm.url }}'
       # {{ end }}
       force: true
+      # {{ if .scm.commitmessage.footers }}
+      commitmessage:
+        footers: '{{ .scm.commitmessage.footers }}'
+      # {{ end }}
 # {{ end }}

--- a/.github/updatecli/values.yaml
+++ b/.github/updatecli/values.yaml
@@ -8,6 +8,7 @@ scm:
   #user: "updatecli[bot]"
   #email: updatecli[bot]@users.noreply.github.com
   branch: main
+  commitusingapi: true
   labels:
     - "dependencies"
     - "updatecli"

--- a/.github/updatecli/values.yaml
+++ b/.github/updatecli/values.yaml
@@ -13,4 +13,4 @@ scm:
     - "dependencies"
     - "updatecli"
   commitmessage:
-    footers: "Signed-off-by: updatecli[bot] <updatecli[bot]@users.noreply.github.com>"
+    footers: "Signed-off-by: Tomas Hehejik <thehejik@suse.com>"

--- a/.github/updatecli/values.yaml
+++ b/.github/updatecli/values.yaml
@@ -12,3 +12,5 @@ scm:
   labels:
     - "dependencies"
     - "updatecli"
+  commitmessage:
+    footers: "Signed-off-by: updatecli[bot] <updatecli[bot]@users.noreply.github.com>"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: Apply
         run: "updatecli pipeline apply --config .github/updatecli/updatecli.d/ --values .github/updatecli/values.yaml"
         env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.UPDATECLI_GITHUB_TOKEN }}"
           UPDATECLI_ACTOR: "${{ github.actor }}"


### PR DESCRIPTION
Updatecli now satisfies DCO sign off requirement for new PRs and CI is able to trigger runs on push event.