### PR TITLE
Use google secret with RUNNER_VERSION_SHA256

### DIFF
--- a/.github/updatecli/updatecli.d/github_runner.yaml
+++ b/.github/updatecli/updatecli.d/github_runner.yaml
@@ -50,3 +50,14 @@ targets:
       file: "scripts/gcp-template-tofu/configure-gh-runner.sh"
       matchpattern: 'RUNNER_SHA256=".*"'
       replacepattern: 'RUNNER_SHA256="{{ source "runnerSha" }}"'
+
+  manualActionNeeded:
+    dependsOn:
+      - source.runnerVersion
+      - source.runnerSha
+    name: '⚠️  ACTION REQUIRED: echo -n "{{ source "runnerVersion" }}:{{ source "runnerSha" }}" | gcloud secrets versions add RUNNER_VERSION_SHA256 --data-file=-'
+    kind: "shell"
+    disablesourceinput: true
+    spec:
+      command: |
+        true # just a placeholder to create a manual action in the updatecli report, the actual command is in the name fields

--- a/scripts/gcp-template-tofu/README.md
+++ b/scripts/gcp-template-tofu/README.md
@@ -113,6 +113,7 @@ The runner bootstrap script reads these Google Secret Manager secrets:
 
 - `GH_REPO_<uuid>`
 - `PAT_TOKEN_<uuid>`
+- `RUNNER_VERSION_SHA256` (optional, set to override the default runner version and SHA256)
 
 `<uuid>` is the hostname suffix and must be 32 lowercase hex characters without dashes.
 
@@ -120,10 +121,12 @@ Example values:
 
 - `GH_REPO_<uuid>`: owner/repo
 - `PAT_TOKEN_<uuid>`: GitHub PAT with permission to request runner registration token
+- `RUNNER_VERSION_SHA256`: runner version and SHA256 in format "VERSION:SHA256" (optional)
 
 Create or update secrets with gcloud (normally handled by the `create-runner` job in the main workflow):
 
 ```bash
 echo -n 'owner/repo' | gcloud secrets create GH_REPO_<uuid> --ttl="36000s" --quiet --data-file=-
 echo -n '<github-pat>' | gcloud secrets create PAT_TOKEN_<uuid> --ttl="36000s" --quiet --data-file=-
+echo -n '2.335.1:4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf' | gcloud secrets create RUNNER_VERSION_SHA256 --data-file=-
 ```

--- a/scripts/gcp-template-tofu/configure-gh-runner.sh
+++ b/scripts/gcp-template-tofu/configure-gh-runner.sh
@@ -8,7 +8,6 @@ RUNNER_HOME=/home/${GH_USER}
 RUNNER_DIR=${RUNNER_HOME}/actions-runner
 RUNNER_VERSION="2.335.1"
 RUNNER_SHA256="4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
-RUNNER_PKG="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 RUNNER_TAR_FILE=runner.tar.gz
 
 echo "$0: started"
@@ -47,6 +46,17 @@ if [[ -z "${PAT_TOKEN}" ]]; then
   echo "$0: PAT_TOKEN not found! stopped"
   exit 1
 fi
+
+# Static secret containg GitHub runner version and its SHA256, in format "VERSION:SHA256"
+RUNNER_VERSION_SHA256=$(${GCLOUD_BIN} secrets versions access latest --secret="RUNNER_VERSION_SHA256")
+if [[ -z "${RUNNER_VERSION_SHA256}" ]]; then
+  echo "$0: Secret RUNNER_VERSION_SHA256 not found! Using default values"
+  RUNNER_VERSION_SHA256="${RUNNER_VERSION}:${RUNNER_SHA256}"
+fi
+
+RUNNER_VERSION=$(echo "${RUNNER_VERSION_SHA256}" | cut -d: -f1)
+RUNNER_SHA256=$(echo "${RUNNER_VERSION_SHA256}" | cut -d: -f2)
+RUNNER_PKG="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 
 # Generate registration token
 # Keep -X POST and --data-raw "" on the same line with curl to ensure the security scan will detect it as API call

--- a/scripts/gcp-template-tofu/configure-gh-runner.sh
+++ b/scripts/gcp-template-tofu/configure-gh-runner.sh
@@ -6,8 +6,6 @@ GH_USER=gh-runner
 GCLOUD_BIN=gcloud
 RUNNER_HOME=/home/${GH_USER}
 RUNNER_DIR=${RUNNER_HOME}/actions-runner
-RUNNER_VERSION="2.335.1"
-RUNNER_SHA256="4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
 RUNNER_TAR_FILE=runner.tar.gz
 
 echo "$0: started"
@@ -47,17 +45,6 @@ if [[ -z "${PAT_TOKEN}" ]]; then
   exit 1
 fi
 
-# Static secret containg GitHub runner version and its SHA256, in format "VERSION:SHA256"
-RUNNER_VERSION_SHA256=$(${GCLOUD_BIN} secrets versions access latest --secret="RUNNER_VERSION_SHA256")
-if [[ -z "${RUNNER_VERSION_SHA256}" ]]; then
-  echo "$0: Secret RUNNER_VERSION_SHA256 not found! Using default values"
-  RUNNER_VERSION_SHA256="${RUNNER_VERSION}:${RUNNER_SHA256}"
-fi
-
-RUNNER_VERSION=$(echo "${RUNNER_VERSION_SHA256}" | cut -d: -f1)
-RUNNER_SHA256=$(echo "${RUNNER_VERSION_SHA256}" | cut -d: -f2)
-RUNNER_PKG="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
-
 # Generate registration token
 # Keep -X POST and --data-raw "" on the same line with curl to ensure the security scan will detect it as API call
 TOKEN=$(curl -fsSL -X POST --data-raw "" \
@@ -70,6 +57,17 @@ if [[ -z "${TOKEN}" || "${TOKEN}" == "null" ]]; then
   echo "$0: registration token not found! stopped"
   exit 1
 fi
+
+# Try to get runner version and SHA256 from secret, fallback to hardcoded defaults
+if RUNNER_VERSION_SHA256=$(${GCLOUD_BIN} secrets versions access latest --secret="RUNNER_VERSION_SHA256" 2>/dev/null); then
+  RUNNER_VERSION=$(echo "${RUNNER_VERSION_SHA256}" | cut -d: -f1)
+  RUNNER_SHA256=$(echo "${RUNNER_VERSION_SHA256}" | cut -d: -f2)
+else
+  echo "$0: Secret RUNNER_VERSION_SHA256 not found! Using default values"
+  RUNNER_VERSION="2.335.1"
+  RUNNER_SHA256="4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
+fi
+RUNNER_PKG="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 
 # Run script to download and configure GitHub runner
 sudo -u ${GH_USER} bash -c "


### PR DESCRIPTION
There was a problem when using hardcoded gh runner version. The version we were using is going to be deprecated. With this change we will use google secret holding actual gh_runner version and its sha256

Once the gcp instance is being provisioned the configuration script will take a look into the secret and will install, validate and configure the version stored there.

if the secret is not present it will use the hardcoded version instead.

By doing this we don't need to recreate the gcp templates every now and then when the runner version is deprecated by github. We will only need to update the secret.

Also I've modified the updatecli pipeline to show command for updating the secret.
```
updatecli pipeline diff --config .github/updatecli/updatecli.d/ --values .github/updatecli/values.yaml
...
SUMMARY:

✔ [updatecli] Bump GitHub Runner:
        Source:
                ✔ [runnerSha] Get GitHub Runner SHA256
                ✔ [runnerVersion] Get latest GitHub Runner version
        Target:
                ✔ [manualActionNeeded] ⚠️  ACTION REQUIRED: echo -n "2.335.1:4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf" | gcloud secrets versions add RUNNER_VERSION_SHA256 --data-file=-
                ✔ [runnerSha] Update RUNNER_SHA256
                      * Repository: https://github.com/rancher-sandbox/rancher-ecp-qa.git (branch: main)
                ✔ [runnerVersion] Update RUNNER_VERSION
                      * Repository: https://github.com/rancher-sandbox/rancher-ecp-qa.git (branch: main)
```

* :green_circle: updatecli testrun https://github.com/rancher-sandbox/rancher-ecp-qa/actions/runs/27971291341